### PR TITLE
override hints component

### DIFF
--- a/config/initializers/simple_form/hints.rb
+++ b/config/initializers/simple_form/hints.rb
@@ -1,0 +1,12 @@
+module SimpleForm
+  module Components
+    # Needs to be enabled in order to do automatic lookups.
+    module Hints
+      def hint(wrapper_options = nil)
+        @hint ||= begin
+          options[:hint].to_s.html_safe if options[:hint].present?
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2050207/41448889-17668c24-7090-11e8-81d8-115aa993beea.png)
智人的input options基本都是写在yaml配置里的，在程序里面专门为hint这个配置项加 html_safe 不太方便。 这里类似bottom hint都html_safe一次。